### PR TITLE
Add an option to show all lookups

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,6 +15,7 @@ module.exports = {
             { extensions: [".js", ".jsx", ".ts", ".tsx"] },
         ],
         "@typescript-eslint/comma-dangle": "off",
+        "react/jsx-wrap-multilines": "off",
         "prettier/prettier": "error",
     },
     parserOptions: {

--- a/src/components/MyDrawer.tsx
+++ b/src/components/MyDrawer.tsx
@@ -13,10 +13,12 @@ import IconButton from "@material-ui/core/IconButton";
 import Chip from "@material-ui/core/Chip";
 import Select from "@material-ui/core/Select";
 import FormControl from "@material-ui/core/FormControl";
+import FormControlLabel from "@material-ui/core/FormControlLabel";
 import MenuItem from "@material-ui/core/MenuItem";
 import InputLabel from "@material-ui/core/InputLabel";
 import TextField from "@material-ui/core/TextField";
 import Autocomplete from "@material-ui/lab/Autocomplete";
+import Checkbox from "@material-ui/core/Checkbox";
 import {
   changedDrawerState,
   changedDirection,
@@ -26,6 +28,7 @@ import {
   changedClusterLevel,
   changedFeatureString,
   changedBufferFlag,
+  changedShowAllLookups,
   CrowbarState,
 } from "../store/actions";
 import { CrowbarFont } from "../opentype/CrowbarFont";
@@ -43,6 +46,7 @@ const mapStateToProps = (state: CrowbarState) => ({
   script: state.script,
   language: state.language,
   bufferFlag: state.bufferFlag,
+  showAllLookups: state.showAllLookups,
 });
 
 const connector = connect(mapStateToProps, {
@@ -54,6 +58,7 @@ const connector = connect(mapStateToProps, {
   changedClusterLevel,
   changedFeatureString,
   changedBufferFlag,
+  changedShowAllLookups,
 });
 type PropsFromRedux = ConnectedProps<typeof connector>;
 
@@ -295,6 +300,16 @@ const MyDrawer = (props: PropsFromRedux) => {
           </MenuItem>
         </Select>
       </FormControl>
+      <FormControlLabel
+        control={
+          <Checkbox
+            name="show-all-lookups"
+            checked={props.showAllLookups}
+            onChange={(e) => props.changedShowAllLookups(e.target.checked)}
+          />
+        }
+        label="Show All Lookups"
+      />
     </Drawer>
   );
 };

--- a/src/components/OutputArea.tsx
+++ b/src/components/OutputArea.tsx
@@ -36,6 +36,7 @@ const mapStateToProps = (state: CrowbarState) => {
     script: state.script,
     language: state.language,
     bufferFlag: state.bufferFlag,
+    showAllLookups: state.showAllLookups,
   };
 };
 

--- a/src/opentype/CrowbarFont.ts
+++ b/src/opentype/CrowbarFont.ts
@@ -32,6 +32,7 @@ export interface ShapingOptions {
   script: string;
   language: string;
   bufferFlag: string[];
+  showAllLookups: boolean;
 }
 
 function onlyUnique(value: any, index: number, self: any) {
@@ -198,6 +199,7 @@ export class CrowbarFont {
         return;
       }
       if (
+        options.showAllLookups ||
         JSON.stringify(r.t) !== lastBuf ||
         (r.m.startsWith("start lookup") &&
           result[ix + 1] &&

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -11,6 +11,7 @@ export const CHANGED_DIRECTION = "CHANGED_DIRECTION";
 export const CHANGED_SCRIPT = "CHANGED_SCRIPT";
 export const CHANGED_LANGUAGE = "CHANGED_LANGUAGE";
 export const CHANGED_BUFFER_FLAG = "CHANGED_BUFFER_FLAG";
+export const CHANGED_SHOW_ALL_LOOKUPS = "CHANGED_SHOW_ALL_LOOKUPS";
 
 export const changedFeatureState = (featureName: string) => ({
   type: CHANGED_FEATURE_STATE,
@@ -45,6 +46,11 @@ export const changedBufferFlag = (bufferFlag: string[]) => ({
 export const changedClusterLevel = (content: number) => ({
   type: CHANGED_CLUSTER_LEVEL,
   clusterLevel: content,
+});
+
+export const changedShowAllLookups = (show: boolean) => ({
+  type: CHANGED_SHOW_ALL_LOOKUPS,
+  showAllLookups: show,
 });
 
 export const changedDrawerState = (open: boolean) => ({
@@ -113,6 +119,7 @@ export interface CrowbarState {
   script: string;
   language: string;
   bufferFlag: string[];
+  showAllLookups: boolean;
 }
 
 export const initialState: CrowbarState = {
@@ -127,4 +134,5 @@ export const initialState: CrowbarState = {
   script: "",
   language: "",
   bufferFlag: [],
+  showAllLookups: false,
 };

--- a/src/store/reducer.ts
+++ b/src/store/reducer.ts
@@ -10,6 +10,7 @@ import {
   CHANGED_FEATURE_STRING,
   CHANGED_CLUSTER_LEVEL,
   CHANGED_BUFFER_FLAG,
+  CHANGED_SHOW_ALL_LOOKUPS,
   initialState,
 } from "./actions";
 
@@ -32,6 +33,8 @@ export default function appReducer(state = initialState, action: any) {
       return { ...state, language: action.language };
     case CHANGED_DRAWER_STATE:
       return { ...state, drawerOpen: action.open };
+    case CHANGED_SHOW_ALL_LOOKUPS:
+      return { ...state, showAllLookups: action.open };
     case ADDED_FONT:
       return {
         ...state,


### PR DESCRIPTION
See https://github.com/simoncozens/crowbar/issues/24

Does not actually work, but I’m sending it just in case someone can make a head or tail of it.

Clicking on the checkbox with cause an error on the console with a link to https://reactjs.org/docs/forms.html#controlled-components which is all Greek to me.

I also had to disable `react/jsx-wrap-multilines` lint rule, because the linter can’t make its mind whether it wants parenthesis or not.