### PR TITLE
Accept files with uppercase file extension

### DIFF
--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -37,11 +37,12 @@ const NavBar = (props: PropsFromRedux) => {
   };
   const onDrop = useCallback(
     (acceptedFiles) => {
+      const name = acceptedFiles[0].name.toLowerCase();
       if (
-        !acceptedFiles[0].name.endsWith(".otf") &&
-        !acceptedFiles[0].name.endsWith(".ttf") &&
-        !acceptedFiles[0].name.endsWith(".ttc") &&
-        !acceptedFiles[0].name.endsWith(".otc")
+        !name.endsWith(".otf") &&
+        !name.endsWith(".ttf") &&
+        !name.endsWith(".ttc") &&
+        !name.endsWith(".otc")
       ) {
         setShaking(true);
       } else {


### PR DESCRIPTION
Old Windows fonts often has names like Foo.TTF or even FOO.TTF, so lowercase the name before checking for file extension.